### PR TITLE
Update settings form help text

### DIFF
--- a/src/Form/CorsAdminForm.php
+++ b/src/Form/CorsAdminForm.php
@@ -53,9 +53,9 @@ class CorsAdminForm extends ConfigFormBase {
         Examples:
         <ul>
           <li>*|http://example.com</li>
-          <li>api|http://example.com:8080 http://example.com</li>
-          <li>api/*|&lt;mirror&gt;,https://example.com</li>
-          <li>api/*|&lt;mirror&gt;|POST|Content-Type,Authorization|true</li>
+          <li>/api|http://example.com:8080 http://example.com</li>
+          <li>/api/*|&lt;mirror&gt;,https://example.com</li>
+          <li>/api/*|&lt;mirror&gt;|POST|Content-Type,Authorization|true</li>
           <li>http://example.com|POST,GET|Content-type,Authorization|true</li>
         </ul>'),
       '#default_value' => $cors_domains,


### PR DESCRIPTION
For now `api/*|http://example.com` will not work because of current path will be `/api/...` (with slash at the start).