### PR TITLE
Fixes for non-working origin header, composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,5 +6,7 @@
   "minimum-stability": "dev",
   "config": {
     "bin-dir": "bin/"
-  }
+  },
+  "name": "drupal/cors",
+  "description": "Drupal CORS module http://drupal.org/project/cors"
 }

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,6 @@
     "bin-dir": "bin/"
   },
   "name": "drupal/cors",
-  "description": "Drupal CORS module http://drupal.org/project/cors"
+  "description": "Drupal CORS module http://drupal.org/project/cors",
+  "type": "drupal-module"
 }

--- a/src/EventSubscriber/CorsResponseEventSubscriber.php
+++ b/src/EventSubscriber/CorsResponseEventSubscriber.php
@@ -90,11 +90,14 @@ class CorsResponseEventSubscriber implements EventSubscriberInterface {
           $origins = explode(',', trim($settings[0]));
           foreach ($origins as $origin) {
             if ($origin === '<mirror>') {
-              if (!empty($request_headers['Origin'])) {
-                $headers['all']['Access-Control-Allow-Origin'][] = $request_headers['Origin'];
+              if (!empty($request_headers['origin'][0])) {
+                $headers['all']['Access-Control-Allow-Origin'][] = $request_headers['origin'][0];
               }
             }
-            else {
+            else if (count($origins) > 1 && ($origin == $request_headers['origin'][0])) {
+              $headers['all']['Access-Control-Allow-Origin'][] = $origin;
+            }
+            else if (count($origins) == 1) {
               $headers['all']['Access-Control-Allow-Origin'][] = $origin;
             }
           }

--- a/src/EventSubscriber/CorsResponseEventSubscriber.php
+++ b/src/EventSubscriber/CorsResponseEventSubscriber.php
@@ -82,15 +82,14 @@ class CorsResponseEventSubscriber implements EventSubscriberInterface {
           $origins = array_map('trim', explode(',', $settings[0]));
           foreach ($origins as $origin) {
             if ($origin === '<mirror>') {
-              if (!empty($request_headers['Origin'])) {
-                $headers_per_path[$path]['Access-Control-Allow-Origin'][] = $request_headers['Origin'];
+              if (!empty($request_headers['origin'])) {
+                $headers_per_path[$path]['Access-Control-Allow-Origin'] = $request_headers['origin'][0];
               }
             }
-            else {
-              $headers_per_path[$path]['Access-Control-Allow-Origin'][] = $origin;
+            else if (count($origins) == 1 || ((count($origins) > 1) && $origin == $request_headers['origin'][0])) {
+              $headers_per_path[$path]['Access-Control-Allow-Origin'] = $origin;
             }
           }
-          $headers_per_path[$path]['Access-Control-Allow-Origin'] = implode(', ', $headers_per_path[$path]['Access-Control-Allow-Origin']);
         }
         if (!empty($settings[1])) {
           $headers_per_path[$path]['Access-Control-Allow-Methods'] = $this->formatMultipleValueHeader($settings[1]);


### PR DESCRIPTION
Instead or returning multiple allowed-origin headers, return only that header that matches with the client. 

I added some missing fields to composer.json, so the project can be used via composer.json directly with an alternate vas settings.
