### PR TITLE
properly allow multiple Access-Control-Allow-Headers

### DIFF
--- a/src/EventSubscriber/CorsResponseEventSubscriber.php
+++ b/src/EventSubscriber/CorsResponseEventSubscriber.php
@@ -104,7 +104,7 @@ class CorsResponseEventSubscriber implements EventSubscriberInterface {
           $headers['OPTIONS']['Access-Control-Allow-Methods'] = explode(',', trim($settings[1]));
         }
         if (!empty($settings[2])) {
-          $headers['OPTIONS']['Access-Control-Allow-Headers'] = explode(',', trim($settings[2]));
+          $headers['OPTIONS']['Access-Control-Allow-Headers'] = array(trim($settings[2]));
         }
         if (!empty($settings[3])) {
           $headers['all']['Access-Control-Allow-Credentials'] = explode(',', trim($settings[3]));


### PR DESCRIPTION
Reference: https://www.drupal.org/files/issues/cors-multiple-Access-Control-Allow-Headers-not-working-2823583-1.patch
patch 2 src: https://www.drupal.org/files/issues/cors-multiple-Access-Control-Allow-Headers-not-working-2823583-1.patch
multiple headers were not properly separating, but instead only the last one of the comma separated list was being used.