### PR TITLE
Removing the limit to 2 lines

### DIFF
--- a/cors.module
+++ b/cors.module
@@ -67,7 +67,7 @@ function cors_admin_form($form, &$form_state) {
  * CORS admin configuration form submit.
  */
 function cors_admin_form_submit($form, &$form_state) {
-  $domains = explode("\n", $form_state['values']['cors_domains'], 2);
+  $domains = explode("\n", $form_state['values']['cors_domains']);
   $settings = array();
   foreach ($domains as $domain) {
     $domain = explode("|", $domain, 2);


### PR DESCRIPTION
Currently, if you add more than 2 lines in the domain text-area, additional domains are not accounted for.

The issue is due to the `explode` 3rd parameter. There is no valid reason to limit the number of cors_domain lines to 2 (as is currently done).

It must be a typo. This PR fixes this.